### PR TITLE
Adding option to provide the ziti identity as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Each JDBC driver needs specific ziti features in order to work.  This table atte
 # How it works
 The zdbc driver registers with `java.sql.DriverManager` when the zdbc wrapper jar is included in the application.  The Ziti JDBC wrapper checks each database URL to see if it starts with `zdbc`.  If it does, then the wrapper accepts the connection request, configures Ziti,  configures the driver,  and then delegates to the driver to establish a database connection over the Ziti network fabric.
 
+# Your Ziti network identity
+The zdbc driver needs your ziti network identity to connect.  There are three ways to give your identity to the driver.
+1. PKCS12 keystore and password.  Provided via the JDBC properties `zitiKeystore` and `zitiKeystorePassword`
+1. Path to a `.json` file containing your ziti identity.  This is the file created during enrollment.  Provided via the JDBC property `zitiIdentityFile`
+1. A zipped and base64encoded string provided via the JDBC property `zitiIdentity`.  The zdbc jar provides a main method that can encode the json ziti identity file into this format.  This option is intended to be used for support tooling or business application deployments where you cannot write to the server file system.
+
 # Example of integrating into developer tools
 ## Requirements
 1.  A Ziti network and database: <https://github.com/openziti/ziti-sdk-jvm/blob/main/samples/jdbc-postgres/cheatsheet.md> 

--- a/build.gradle
+++ b/build.gradle
@@ -69,11 +69,17 @@ ext {
 version = "${semver.info}"
 
 dependencies {
-  	compileOnly 'org.openziti:ziti:0.23.+'
+   compileOnly 'org.openziti:ziti:+'
 }
 
 tasks.withType(PublishToMavenRepository).all {
     onlyIf { !semver.info.dirty }
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'org.openziti.jdbc.CommandLine'
+    }
 }
 
 publishing {

--- a/src/main/java/org/openziti/jdbc/CommandLine.java
+++ b/src/main/java/org/openziti/jdbc/CommandLine.java
@@ -1,0 +1,57 @@
+package org.openziti.jdbc;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.zip.GZIPOutputStream;
+
+public class CommandLine {
+
+  private static void printUsageAndExit() {
+    System.out.println("Usage:  java -jar zdbc.jar -e /path/to/identity.json");
+    System.out.println("\t -e  Encode a Ziti identity file for use as zitiIdentity jdbc driver property");
+    System.out.println("\t        The file is gzipped and base64 encoded");
+    System.exit(1);
+  }
+  
+  private static String encodeIdentity(File input) throws IOException {
+    
+    FileInputStream fis = new FileInputStream(input);
+    byte[] buffer = new byte[1024];
+    
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    GZIPOutputStream gzip = new GZIPOutputStream(out);
+    
+    int len = 0;
+    while( -1 != (len = fis.read(buffer))) {
+      gzip.write(buffer, 0, len);
+    }
+    gzip.close();
+
+    String encodedIdentity = Base64.getEncoder().encodeToString(out.toByteArray());
+    return encodedIdentity;
+  }
+  
+  public static void main(String[] args) {
+    if (args.length != 2) {
+      printUsageAndExit();      
+    }
+    if (!"-e".equals(args[0])) {
+      printUsageAndExit(); 
+    }
+    
+    File identity = new File(args[1]);
+    if( !identity.exists() || !identity.canRead()) {
+      System.out.println("identity file " + identity.getAbsolutePath() + " does not exist or could not be read");
+      printUsageAndExit();
+    }
+    
+    try { 
+      System.out.println(encodeIdentity(identity));
+    } catch (IOException e) {
+      System.err.println("Failed to encode " + identity.getAbsolutePath() + "," + e.getMessage());
+    }
+  }
+}

--- a/src/main/java/org/openziti/jdbc/ZitiDriver.java
+++ b/src/main/java/org/openziti/jdbc/ZitiDriver.java
@@ -3,6 +3,10 @@ package org.openziti.jdbc;
 
 import static org.openziti.jdbc.ZitiDriver.ZitiFeature.nioProvider;
 import static org.openziti.jdbc.ZitiDriver.ZitiFeature.seamless;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
@@ -12,12 +16,14 @@ import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
 import org.openziti.Ziti;
 
 public class ZitiDriver implements java.sql.Driver {
@@ -28,6 +34,7 @@ public class ZitiDriver implements java.sql.Driver {
   private static Set<BaseZitiDriverShim> configuredShims = new HashSet<>();
 
   public static final String ZITI_JSON = "zitiIdentityFile";
+  public static final String ZITI_IDENTITY = "zitiIdentity";
   public static final String ZITI_KEYSTORE = "zitiKeystore";
   public static final String ZITI_KEYSTORE_PASSWORD = "zitiKeystorePassword";
   public static final String ZITI_DRIVER_URL_PATTERN = "zitiDriverUrlPattern";
@@ -76,6 +83,10 @@ public class ZitiDriver implements java.sql.Driver {
   @Override
   public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
 
+    DriverPropertyInfo identity = new DriverPropertyInfo(ZITI_IDENTITY, "Ziti Identity");
+    identity.description = "Ziti Identity json.  Zipped and base64 encoded";
+    identity.required = false;
+
     DriverPropertyInfo identityFile = new DriverPropertyInfo(ZITI_JSON, "/path/to/identity.json");
     identityFile.description = "Ziti identify file to use for the connection";
     identityFile.required = false;
@@ -84,7 +95,8 @@ public class ZitiDriver implements java.sql.Driver {
     keystoreFile.description = "Keystore containing one or more Ziti identities";
     keystoreFile.required = false;
 
-    DriverPropertyInfo keystorePassword = new DriverPropertyInfo(ZITI_KEYSTORE_PASSWORD, "secretPassword");
+    DriverPropertyInfo keystorePassword =
+        new DriverPropertyInfo(ZITI_KEYSTORE_PASSWORD, "secretPassword");
     keystorePassword.description = "Password for the Ziti keystore";
     keystorePassword.required = false;
 
@@ -96,28 +108,34 @@ public class ZitiDriver implements java.sql.Driver {
 
       DriverPropertyInfo[] props = shim.getDelegate().getPropertyInfo(dbUrl, info);
 
-      DriverPropertyInfo[] result = new DriverPropertyInfo[props.length + 3];
-      result[0] = identityFile;
-      result[1] = keystoreFile;
-      result[2] = keystorePassword;
-      System.arraycopy(props, 0, result, 3, props.length);
+      DriverPropertyInfo[] result = new DriverPropertyInfo[props.length + 4];
+      result[0] = identity;
+      result[1] = identityFile;
+      result[2] = keystoreFile;
+      result[3] = keystorePassword;
+      System.arraycopy(props, 0, result, 4, props.length);
 
       return result;
     } catch (ShimException e) {
-      // No shim could be found, and no shim could be registered. Return the basic properties to define a
+      // No shim could be found, and no shim could be registered. Return the basic properties to
+      // define a
       // shim
 
-      log.fine("Ziti driver could not find a shim for url: " + url + ".  Returning basic properties.");
-      
-      DriverPropertyInfo driverUrlPattern = new DriverPropertyInfo(ZITI_DRIVER_URL_PATTERN, "^zdbc:<database>.*");
+      log.fine(
+          "Ziti driver could not find a shim for url: " + url + ".  Returning basic properties.");
+
+      DriverPropertyInfo driverUrlPattern =
+          new DriverPropertyInfo(ZITI_DRIVER_URL_PATTERN, "^zdbc:<database>.*");
       identityFile.description = "Regular expression used to identify the jdbc URL for this driver";
       identityFile.required = true;
 
-      DriverPropertyInfo driverClassName = new DriverPropertyInfo(ZITI_DRIVER_CLASSNAME, "org.jdbc.Driver");
+      DriverPropertyInfo driverClassName =
+          new DriverPropertyInfo(ZITI_DRIVER_CLASSNAME, "org.jdbc.Driver");
       keystoreFile.description = "The JDBC driver to delegate to";
       keystoreFile.required = true;
 
-      DriverPropertyInfo zitiFeatures = new DriverPropertyInfo(ZITI_DRIVER_FEATURES, "seamless,nioProvider");
+      DriverPropertyInfo zitiFeatures =
+          new DriverPropertyInfo(ZITI_DRIVER_FEATURES, "seamless,nioProvider");
       keystorePassword.description = "Ziti driver features required for the JDBC driver";
       keystorePassword.required = true;
 
@@ -128,7 +146,7 @@ public class ZitiDriver implements java.sql.Driver {
       result[3] = driverUrlPattern;
       result[4] = driverClassName;
       result[5] = zitiFeatures;
-      
+
       return result;
     }
   }
@@ -145,7 +163,8 @@ public class ZitiDriver implements java.sql.Driver {
 
   @Override
   public boolean jdbcCompliant() {
-    // The JDBC driver provided by the shim may be JDBC compliant, but this driver cannot know that for
+    // The JDBC driver provided by the shim may be JDBC compliant, but this driver cannot know that
+    // for
     // sure.
     // It is forced to return false to be compliant with the spec.
     return false;
@@ -204,49 +223,86 @@ public class ZitiDriver implements java.sql.Driver {
 
   private synchronized void setupZiti(BaseZitiDriverShim shim, Properties info) {
 
-    if (zitiConfigs.contains(info.getProperty(ZITI_JSON)) || zitiConfigs.contains(info.getProperty(ZITI_KEYSTORE))) {
+    if (zitiConfigs.contains(info.getProperty(ZITI_JSON))
+        || zitiConfigs.contains(info.getProperty(ZITI_KEYSTORE))
+        || zitiConfigs.contains(info.getProperty(ZITI_IDENTITY))) {
       log.finest("Ziti has already been configured, skipping setup");
       return;
     }
 
-    if (info.containsKey(ZITI_JSON) || info.containsKey(ZITI_KEYSTORE)) {
-      log.info("Ziti JDBC wrapper is configuring Ziti identities. Production applications should manage Ziti identities directly");
+    if (info.containsKey(ZITI_JSON) || info.containsKey(ZITI_KEYSTORE)
+        || info.containsKey(ZITI_IDENTITY)) {
+      log.info(
+          "Ziti JDBC wrapper is configuring Ziti identities. Production applications should manage Ziti identities directly");
     }
 
 
     // Check to see if NIO feature is required
     if (!configuredShims.contains(shim) && requiresFeature(shim, nioProvider)) {
-      log.info("Ziti JDBC wrapper is setting the system property 'java.nio.channels.spi.SelectorProvider' to 'org.openziti.net.nio.ZitiSelectorProvider'");
-      System.setProperty("java.nio.channels.spi.SelectorProvider", "org.openziti.net.nio.ZitiSelectorProvider");
+      log.info(
+          "Ziti JDBC wrapper is setting the system property 'java.nio.channels.spi.SelectorProvider' to 'org.openziti.net.nio.ZitiSelectorProvider'");
+      System.setProperty("java.nio.channels.spi.SelectorProvider",
+          "org.openziti.net.nio.ZitiSelectorProvider");
     }
 
     if (info.containsKey(ZITI_JSON)) {
-      log.finer(() -> String.format("Found identity file %s in connection properties.", info.getProperty(ZITI_JSON)));
+      log.finer(() -> String.format("Found identity file %s in connection properties.",
+          info.getProperty(ZITI_JSON)));
 
       Ziti.init(info.getProperty(ZITI_JSON), "".toCharArray(), requiresFeature(shim, seamless));
-      log.finer(() -> {
-        StringBuilder sb = new StringBuilder("Current Ziti contexts: ");
-        Ziti.getContexts().forEach(c -> sb.append("\t").append(c).append("\n"));
-        return sb.toString();
-      });
 
       zitiConfigs.add(info.getProperty(ZITI_JSON));
     } else if (info.containsKey(ZITI_KEYSTORE)) {
 
-      log.finer(() -> String.format("Found keystore file %s in connection properties.", info.getProperty(ZITI_KEYSTORE)));
-      Ziti.init(info.getProperty(ZITI_KEYSTORE), info.getProperty(ZITI_KEYSTORE_PASSWORD).toCharArray(), requiresFeature(shim, seamless));
+      log.finer(() -> String.format("Found keystore file %s in connection properties.",
+          info.getProperty(ZITI_KEYSTORE)));
+      Ziti.init(info.getProperty(ZITI_KEYSTORE),
+          info.getProperty(ZITI_KEYSTORE_PASSWORD).toCharArray(), requiresFeature(shim, seamless));
       zitiConfigs.add(info.getProperty(ZITI_KEYSTORE));
+    } else if (info.containsKey(ZITI_IDENTITY)) {
+      log.finer(() -> String.format("Found ziti identity connection properties."));
+
+      byte[] decoded = Base64.getDecoder().decode(info.getProperty(ZITI_IDENTITY).getBytes());
+
+      try (
+          ByteArrayInputStream is = new ByteArrayInputStream(decoded);
+          GZIPInputStream gz = new GZIPInputStream(is);) {
+ 
+        Ziti.init(toByteArray(gz), requiresFeature(shim, seamless));
+        zitiConfigs.add(info.getProperty(ZITI_KEYSTORE));
+
+      } catch (IOException ioe) {
+        throw new IllegalArgumentException(
+            ZITI_IDENTITY + " is expected to be a base64 encoded, gzipped value.");
+      }
     }
-//
-//    if(!configuredShims.contains(shim) && requiresFeature(shim, seamless) && !Ziti.isSeamless()) {
-//      throw new ShimException(String.format("Ziti JDBC configuration error. JDBC driver %s requires ziti seamless mode, but it is not enabled",
-//          shim.getDelegate().getClass().getName()));
-//    }
-//
+    
+    if (!configuredShims.contains(shim) && requiresFeature(shim, seamless) && !Ziti.isSeamless()) {
+      throw new ShimException(String.format(
+          "Ziti JDBC configuration error. JDBC driver %s requires ziti seamless mode, but it is not enabled",
+          shim.getDelegate().getClass().getName()));
+    }
+    
     log.fine("Ziti initialized");
     configuredShims.add(shim);
   }
 
+  protected static byte[] toByteArray(InputStream is) throws IOException {
+    // Copy the unzipped identity to a byte array
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+    int nRead;
+    byte[] data = new byte[1024];
+
+    while ((nRead = is.read(data, 0, data.length)) != -1) {
+      buffer.write(data, 0, nRead);
+    }
+
+    buffer.flush();
+    byte result[] = buffer.toByteArray();
+    return result;
+  }
+  
   protected static boolean requiresFeature(BaseZitiDriverShim shim, ZitiFeature feature) {
     return null != shim.getZitiFeatures() && shim.getZitiFeatures().contains(feature);
   }
@@ -271,7 +327,8 @@ public class ZitiDriver implements java.sql.Driver {
         info.setProperty(token, "");
       } else {
         try {
-          info.setProperty(token.substring(0, pos), URLDecoder.decode(token.substring(pos + 1), Charset.defaultCharset().name()));
+          info.setProperty(token.substring(0, pos),
+              URLDecoder.decode(token.substring(pos + 1), Charset.defaultCharset().name()));
         } catch (UnsupportedEncodingException e) {
           throw new SQLException(e);
         }


### PR DESCRIPTION
This PR requires Ziti Java SDK PR: https://github.com/openziti/ziti-sdk-jvm/pull/265 to be merged first.